### PR TITLE
Terraform 0.7

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -3,5 +3,5 @@ output "vpc_id" {
 }
 
 output "subnets" {
-  value = "${join(",", aws_subnet.main.*.id)}"
+  value = ["${aws_subnet.main.*.id}"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -13,10 +13,6 @@ variable "amount_subnets" {
   default = "3"
 }
 
-
-/*
-this currently doesn't allow to change value from module as described here:
-https://github.com/hashicorp/terraform/issues/1336
 variable "subnets" {
   description = "Availability zones"
   default = {
@@ -25,18 +21,8 @@ variable "subnets" {
     "2" = "c"
     "3" = "d"
   }
-}*/
+}
 
-/*Adding this workaround*/
-variable "subnets-keys" {
-  description = "Availability zones keys"
-  default = "0,1,2,3"
-}
-variable "subnets-values" {
-  description = "Availability zones values"
-  default = "a,b,c,d"
-}
-/*end workaround*/
 variable "subnets_cidr_block" {
   description = "Subnets that you need, this needs to be , delimited"
   type = "list"

--- a/variables.tf
+++ b/variables.tf
@@ -39,7 +39,8 @@ variable "subnets-values" {
 /*end workaround*/
 variable "subnets_cidr_block" {
   description = "Subnets that you need, this needs to be , delimited"
-  default =  "10.0.0.0/24,10.0.1.0/24,10.0.2.0/24,10.0.3.0/24"
+  type = "list"
+  default =  ["10.0.0.0/24","10.0.1.0/24","10.0.2.0/24","10.0.3.0/24"]
 }
 
 variable "environment" {

--- a/vpc.tf
+++ b/vpc.tf
@@ -15,12 +15,11 @@ resource "aws_vpc" "main" {
 resource "aws_subnet" "main" {
   count = "${var.amount_subnets}"
   vpc_id = "${aws_vpc.main.id}"
-  cidr_block = "${element(split(",", var.subnets_cidr_block), count.index)}"
-  /*Implementing lookup workaround for subnets*/
-  availability_zone = "${concat(var.aws_region, element(split(",", var.subnets-values),index(split(",",var.subnets-keys),count.index)))}"
+  cidr_block = "${element(var.subnets_cidr_block, count.index)}"
+  availability_zone = "${var.aws_region}${lookup(var.subnets, count.index)}"
 
   tags {
-    Name = "${var.environment}-${concat(var.aws_region, element(split(",", var.subnets-values),index(split(",",var.subnets-keys),count.index)))}"
+    Name = "${var.environment}-${var.aws_region}${lookup(var.subnets, count.index)}"
     Environment = "${var.environment}"
     Project = "${var.project}"
   }


### PR DESCRIPTION
this makes the module compatible with terraform 0.7

the output of subnets is now a list.
the workaround can be removed in this version.
